### PR TITLE
Fix `application` and `sdk` generators showing outdated example options

### DIFF
--- a/.changeset/tame-cooks-greet.md
+++ b/.changeset/tame-cooks-greet.md
@@ -1,0 +1,5 @@
+---
+'nx-mesh': patch
+---
+
+Fix `application` & `sdk` generators showing outdated examples

--- a/libs/nx-mesh/src/generators/application/schema.json
+++ b/libs/nx-mesh/src/generators/application/schema.json
@@ -52,10 +52,23 @@
       }
     },
     "example": {
-      "description": "Which example project would you like to use?",
+      "description": "Which example project would you like to start with?",
       "type": "string",
-      "enum": ["javascriptWiki", "stackexchange", "trippin", "country-info"],
-      "default": "javascriptWiki"
+      "default": "star-wars-api",
+      "x-prompt": {
+        "message": "Which example project would you like to start with?",
+        "type": "list",
+        "items": [
+          { "value": "country-info", "label": "Country Info (SOAP)" },
+          { "value": "fake-api", "label": "Fake API (JSON Schema)" },
+          { "value": "javascript-wiki", "label": "JavaScript Wiki (OpenAPI)" },
+          { "value": "movies", "label": "Movies (Neo4j)" },
+          { "value": "rfam", "label": "RFam (MySQL)" },
+          { "value": "stackexchange", "label": "StackExchange (OpenAPI)" },
+          { "value": "star-wars-api", "label": "Star Wars API (GraphQL)" },
+          { "value": "trippin", "label": "Trip Pin (odata)" }
+        ]
+      }
     },
     "linter": {
       "description": "The tool to use for running lint checks.",

--- a/libs/nx-mesh/src/generators/sdk/schema.json
+++ b/libs/nx-mesh/src/generators/sdk/schema.json
@@ -45,10 +45,23 @@
       }
     },
     "example": {
-      "description": "Which example project would you like to use?",
+      "description": "Which example project would you like to start with?",
       "type": "string",
-      "enum": ["javascriptWiki", "stackexchange", "trippin", "country-info"],
-      "default": "javascriptWiki"
+      "default": "star-wars-api",
+      "x-prompt": {
+        "message": "Which example project would you like to start with?",
+        "type": "list",
+        "items": [
+          { "value": "country-info", "label": "Country Info (SOAP)" },
+          { "value": "fake-api", "label": "Fake API (JSON Schema)" },
+          { "value": "javascript-wiki", "label": "JavaScript Wiki (OpenAPI)" },
+          { "value": "movies", "label": "Movies (Neo4j)" },
+          { "value": "rfam", "label": "RFam (MySQL)" },
+          { "value": "stackexchange", "label": "StackExchange (OpenAPI)" },
+          { "value": "star-wars-api", "label": "Star Wars API (GraphQL)" },
+          { "value": "trippin", "label": "Trip Pin (odata)" }
+        ]
+      }
     },
     "simpleModuleName": {
       "description": "Keep the module name simple (when using `--directory`).",


### PR DESCRIPTION
Both generators are still showing the exampe options from version 1. The schemas need to be updated to reflect the new options from the `base` generator.

## What's Changed?

- Update `application` & `sdk` schemas to reflect `base` options.