### PR TITLE
Fix Nx peer dependencies

### DIFF
--- a/.changeset/dirty-camels-lick.md
+++ b/.changeset/dirty-camels-lick.md
@@ -1,0 +1,5 @@
+---
+'nx-mesh': patch
+---
+
+Fix peer dependency ranges

--- a/.github/actions/setup-job/action.yml
+++ b/.github/actions/setup-job/action.yml
@@ -18,6 +18,11 @@ inputs:
       Pass `config` (default value) to use the Volta config.
     required: false
     default: 'config'
+  skip_node_cache:
+    description: >
+      Should node_modules cahce be skipped?
+    required: false
+    default: 'false'
   save_cache:
     description: Should the cache be saved upon completion?
     required: false
@@ -45,6 +50,9 @@ outputs:
       The value intended for use with --head or NX_HEAD in all subsequent
       `nx affected` commands within the current workflow.
     value: ${{ steps.nx_shas.outputs.head }}
+  pnpm_directory:
+    description: The installed pnpm directory.
+    value: ${{ steps.directory.outputs.path }}
   pnpm_version:
     description: The installed pnpm version.
     value: ${{ steps.pnpm.outputs.version }}
@@ -192,24 +200,28 @@ runs:
 
     - name: Create restore cache key
       id: restore_cache_key
+      if: inputs.skip_node_cache == 'false'
       shell: bash
       run: |
         echo "key=cache-version-7--os-${{ runner.os }}--volta-${{ steps.volta.outputs.version }}--node-${{ steps.node.outputs.version }}--pnpm-${{ steps.pnpm.outputs.version }}" >> $GITHUB_OUTPUT
 
     - name: Create cache key
       id: cache_key
+      if: inputs.skip_node_cache == 'false'
       shell: bash
       run: |
         echo "key=${{ steps.restore_cache_key.outputs.key }}--lockfile-${{ hashFiles('*/pnpm-lock.yaml') }}" >> $GITHUB_OUTPUT
 
     - name: Nx Shas
       id: nx_shas
+      if: inputs.skip_node_cache == 'false'
       uses: nrwl/nx-set-shas@v3
 
     # Restore Cache
 
     - name: Restore PNPM cache
       uses: actions/cache/restore@v3
+      if: inputs.skip_node_cache == 'false'
       id: pnpm-cache
       with:
         path: |
@@ -224,7 +236,7 @@ runs:
     - name: Restore Cypress Cache
       uses: actions/cache@v3
       id: cypress-cache
-      if: inputs.browsers == 'true'
+      if: inputs.browsers == 'true' && inputs.skip_node_cache == 'false'
       with:
         path: |
           ~/.cache/Cypress
@@ -236,7 +248,7 @@ runs:
     # Install
 
     - name: Install Node Dependencies
-      if: steps.pnpm-cache.outputs.cache-hit != 'true'
+      if: steps.pnpm-cache.outputs.cache-hit != 'true' && inputs.skip_node_cache == 'false'
       shell: bash
       run: |
         pnpm install --frozen-lockfile
@@ -245,13 +257,14 @@ runs:
 
     - name: Affected
       id: affected
+      if: inputs.skip_node_cache == 'false'
       uses: ./.github/actions/nx-affected
 
     # Save Cache
 
     - name: Save Cypress cache
       uses: actions/cache/save@v3
-      if: inputs.save_cache == 'true' && steps.pnpm-cache.outputs.cache-hit != 'true'
+      if: inputs.save_cache == 'true' && steps.pnpm-cache.outputs.cache-hit != 'true' && inputs.skip_node_cache == 'false'
       with:
         path: |
           ~/.cache/Cypress
@@ -260,7 +273,7 @@ runs:
 
     - name: Save PNPM cache
       uses: actions/cache/save@v3
-      if: inputs.save_cache == 'true' && steps.pnpm-cache.outputs.cache-hit != 'true'
+      if: inputs.save_cache == 'true' && steps.pnpm-cache.outputs.cache-hit != 'true' && inputs.skip_node_cache == 'false'
       with:
         path: |
           ${{ steps.pnpm.outputs.cache_dir }}

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -86,11 +86,17 @@ jobs:
             --all \
             --configuration=production
 
-      - name: Upload Nx-mesh build artifact
+      - name: Create build artifact tar
+        if: inputs.node_version == 'lts'
+        shell: bash
+        run: |
+          tar cvzf nx-mesh.tar.gz dist/libs/nx-mesh/
+
+      - name: Upload build artifact
         uses: actions/upload-artifact@v3
+        if: inputs.node_version == 'lts'
         with:
           name: nx-mesh
           retention-days: 2
           path: |
-            dist/libs/nx-mesh/
-            !dist/libs/nx-mesh/node_modules
+            nx-mesh.tar.gz

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -90,7 +90,9 @@ jobs:
         if: inputs.node_version == 'lts'
         shell: bash
         run: |
-          tar cvzf nx-mesh.tar.gz dist/libs/nx-mesh/
+          cd dist/libs
+          tar cvzf nx-mesh.tar.gz nx-mesh
+          mv nx-mesh.tar.gz ../../
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -85,3 +85,12 @@ jobs:
             --parallel=2 \
             --all \
             --configuration=production
+
+      - name: Upload Nx-mesh build artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: nx-mesh
+          retention-days: 2
+          path: |
+            dist/libs/nx-mesh/
+            !dist/libs/nx-mesh/node_modules

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -32,7 +32,7 @@ on:
         required: true
 
 concurrency:
-  group: build--${{ github.workflow }}--${{ github.ref }}
+  group: build--${{ github.workflow }}--${{ github.ref }}--node-${{ inputs.node_version }}--affected-${{ inputs.affected }}--save_cache-${{ inputs.save_cache }}
 
 env:
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}

--- a/.github/workflows/_generators.yml
+++ b/.github/workflows/_generators.yml
@@ -57,12 +57,8 @@ jobs:
           - 'star-wars-api'
           - 'trippin'
         nx_version:
-          - 14.8
-          - 15
-          - 15.1
-          - 15.2
-          - 15.3
           - 15.4
+          - 15.5
           - latest
     steps:
       - name: Check out repository
@@ -98,7 +94,7 @@ jobs:
           pnpm dlx create-nx-workspace@${{ matrix.nx_version }} \
             --name=generator \
             --appName=${{ matrix.example }} \
-            --preset=ts \
+            --preset=apps \
             --interactive=false \
             --nxCloud=false \
             --style=css \

--- a/.github/workflows/_generators.yml
+++ b/.github/workflows/_generators.yml
@@ -97,7 +97,7 @@ jobs:
             --style=css \
             --skipGit
           cd generator
-          pnpm add /home/runner/work/nx-mesh/nx-mesh
+          pnpm add /home/runner/work/nx-mesh/nx-mesh.tar.gz
           pnpm exec nx generate nx-mesh:${{ matrix.type }} ${{ matrix.example }} \
             --example=${{ matrix.example }} \
             --no-interactive

--- a/.github/workflows/_generators.yml
+++ b/.github/workflows/_generators.yml
@@ -55,22 +55,47 @@ jobs:
           - 'stackexchange'
           - 'star-wars-api'
           - 'trippin'
+        nx_version: [latest, 15.4, 15.3, 15.2, 15.1, 15.0, 14]
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      # - name: Check out repository
+      #   uses: actions/checkout@v3
+      #   with:
+      #     fetch-depth: 0
 
       - name: Setup Job
         uses: ./.github/actions/setup-job
+        id: setup
         with:
           node_version: ${{ inputs.node_version }}
-          save_cache: '${{ inputs.save_cache }}'
+          skip_node_cache: 'true'
 
-      - name: Build Nx-mesh
+      - name: Restore PNPM cache
+        uses: actions/cache/restore@v3
+        id: pnpm-cache
+        with:
+          path: |
+            ${{ steps.setup.outputs.pnpm_directory }}
+          key: |
+            generators--pnpm--nx-${{ matrix.nx_version }}--type-${{ matrix.type }}--example-${{ matrix.example }}
+
+      - name: Download Nx Mesh
+        uses: actions/download-artifact@v3
+        with:
+          name: nx-mesh
+
+      - name: Generate repo
         shell: bash
         run: |
-          pnpm nx run nx-mesh:build
+          ls -1a
+          pnpm dlx create-nx-workspace@${{ matrix.nx_version }} \
+            --name=generator \
+            --appName=${{ matrix.nx_version }} \
+            --preset=ts \
+            --interactive=false \
+            --nxCloud=false \
+            --style=css
+          cd generator
+          pnpm add ../dist/libs/nx-mesh/
 
       - name: Generate Example
         shell: bash
@@ -84,3 +109,12 @@ jobs:
         shell: bash
         run: |
           pnpm nx run ${{ matrix.example }}:build
+
+      - name: Save PNPM cache
+        uses: actions/cache/save@v3
+        if: inputs.save_cache == 'true' && steps.pnpm-cache.outputs.cache-hit != 'true' && inputs.skip_node_cache == 'false'
+        with:
+          path: |
+            ${{ steps.setup.outputs.pnpm_directory }}
+          key: |
+            generators--pnpm--nx-${{ matrix.nx_version }}--type-${{ matrix.type }}--example-${{ matrix.example }}

--- a/.github/workflows/_generators.yml
+++ b/.github/workflows/_generators.yml
@@ -87,32 +87,25 @@ jobs:
       - name: Generate repo with example
         shell: bash
         run: |
-          ls -1a
           cd ../
-          ls -1a
           pnpm dlx create-nx-workspace@${{ matrix.nx_version }} \
             --name=generator \
             --appName=${{ matrix.nx_version }} \
-            --preset=ts \
+            --preset=next \
             --interactive=false \
             --nxCloud=false \
             --style=css \
             --skipGit
           cd generator
-          ls -1a
           pnpm add /home/runner/work/nx-mesh/nx-mesh
-          ls -1a
           pnpm exec nx generate nx-mesh:${{ matrix.type }} ${{ matrix.example }} \
             --example=${{ matrix.example }} \
             --no-interactive
-          ls -1a
 
       - name: Build example
         shell: bash
         run: |
-          ls -1a
           cd generator/${{ matrix.example }}
-          ls -1a
           pnpm nx run ${{ matrix.example }}:build
 
       - name: Save PNPM cache

--- a/.github/workflows/_generators.yml
+++ b/.github/workflows/_generators.yml
@@ -87,7 +87,9 @@ jobs:
       - name: Generate repo with example
         shell: bash
         run: |
+          ls -1a
           cd ../
+          ls -1a
           pnpm dlx create-nx-workspace@${{ matrix.nx_version }} \
             --name=generator \
             --appName=${{ matrix.example }} \
@@ -97,7 +99,7 @@ jobs:
             --style=css \
             --skipGit
           cd generator
-          pnpm add /home/runner/work/nx-mesh/nx-mesh.tar.gz
+          pnpm add ../nx-mesh/nx-mesh.tar.gz
           pnpm exec nx generate nx-mesh:${{ matrix.type }} ${{ matrix.example }} \
             --example=${{ matrix.example }} \
             --no-interactive

--- a/.github/workflows/_generators.yml
+++ b/.github/workflows/_generators.yml
@@ -88,7 +88,6 @@ jobs:
         shell: bash
         run: |
           ls -1a
-          ls -1a nx-mesh
           cd ../
           ls -1a
           pnpm dlx create-nx-workspace@${{ matrix.nx_version }} \
@@ -101,7 +100,7 @@ jobs:
             --skipGit
           cd generator
           ls -1a
-          pnpm add ../nx-mesh/nx-mesh/
+          pnpm add /home/runner/work/nx-mesh/nx-mesh
           ls -1a
           pnpm exec nx generate nx-mesh:${{ matrix.type }} ${{ matrix.example }} \
             --example=${{ matrix.example }} \

--- a/.github/workflows/_generators.yml
+++ b/.github/workflows/_generators.yml
@@ -84,7 +84,7 @@ jobs:
         with:
           name: nx-mesh
 
-      - name: Generate repo with example
+      - name: Test Generator - (nx-${{ matrix.nx_version }}/${{ matrix.type }}-${{ matrix.example }})
         shell: bash
         run: |
           cd ../
@@ -98,15 +98,10 @@ jobs:
             --skipGit
           cd generator
           pnpm add ../nx-mesh/nx-mesh.tar.gz
-          pnpm exec nx generate nx-mesh:${{ matrix.type }} ${{ matrix.example }} \
+          pnpm exec nx generate nx-mesh:${{ matrix.type }} \
+            ${{ matrix.example }} \
             --example=${{ matrix.example }} \
             --no-interactive
-
-      - name: Build example
-        shell: bash
-        run: |
-          ls -1a
-          cd ../generator/${{ matrix.example }}
           pnpm nx run ${{ matrix.example }}:build
 
       - name: Save PNPM cache

--- a/.github/workflows/_generators.yml
+++ b/.github/workflows/_generators.yml
@@ -87,7 +87,11 @@ jobs:
       - name: Generate repo with example
         shell: bash
         run: |
+          ls -1a
+          ls -1a dist
+          ls -1a dist/libs/nx-mesh
           cd ../
+          ls -1a
           pnpm dlx create-nx-workspace@${{ matrix.nx_version }} \
             --name=generator \
             --appName=${{ matrix.nx_version }} \

--- a/.github/workflows/_generators.yml
+++ b/.github/workflows/_generators.yml
@@ -45,16 +45,17 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        type: [application, sdk, preset]
+        type: [application]
+        # type: [application, sdk, preset]
         example:
           - 'country-info'
-          - 'fake-api'
-          - 'javascript-wiki'
-          # - 'movies'
-          - 'rfam'
-          - 'stackexchange'
-          - 'star-wars-api'
-          - 'trippin'
+          # - 'fake-api'
+          # - 'javascript-wiki'
+          # # - 'movies'
+          # - 'rfam'
+          # - 'stackexchange'
+          # - 'star-wars-api'
+          # - 'trippin'
         nx_version: [15.4]
     steps:
       - name: Check out repository
@@ -102,6 +103,7 @@ jobs:
       - name: Generate Example
         shell: bash
         run: |
+          ls -1a
           pnpm exec nx generate nx-mesh:${{ matrix.type }} ${{ matrix.example }} \
             --example=${{ matrix.example }} \
             --no-interactive

--- a/.github/workflows/_generators.yml
+++ b/.github/workflows/_generators.yml
@@ -45,8 +45,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        type: [application]
-        # type: [application, sdk, preset]
+        type: [application, sdk, preset]
         example:
           - 'country-info'
           # - 'fake-api'
@@ -106,7 +105,6 @@ jobs:
 
       - name: Save PNPM cache
         uses: actions/cache/save@v3
-        if: inputs.save_cache == 'true' && steps.pnpm-cache.outputs.cache-hit != 'true' && inputs.skip_node_cache == 'false'
         with:
           path: |
             ${{ steps.setup.outputs.pnpm_directory }}

--- a/.github/workflows/_generators.yml
+++ b/.github/workflows/_generators.yml
@@ -84,7 +84,7 @@ jobs:
         with:
           name: nx-mesh
 
-      - name: Generate repo
+      - name: Generate repo with example
         shell: bash
         run: |
           cd ../
@@ -99,18 +99,18 @@ jobs:
           cd generator
           ls -1a
           pnpm add ../project/dist/libs/nx-mesh/
-
-      - name: Generate Example
-        shell: bash
-        run: |
           ls -1a
           pnpm exec nx generate nx-mesh:${{ matrix.type }} ${{ matrix.example }} \
             --example=${{ matrix.example }} \
             --no-interactive
+          ls -1a
 
       - name: Build example
         shell: bash
         run: |
+          ls -1a
+          cd generator/${{ matrix.example }}
+          ls -1a
           pnpm nx run ${{ matrix.example }}:build
 
       - name: Save PNPM cache

--- a/.github/workflows/_generators.yml
+++ b/.github/workflows/_generators.yml
@@ -87,9 +87,7 @@ jobs:
       - name: Generate repo with example
         shell: bash
         run: |
-          ls -1a
           cd ../
-          ls -1a
           pnpm dlx create-nx-workspace@${{ matrix.nx_version }} \
             --name=generator \
             --appName=${{ matrix.example }} \
@@ -107,7 +105,8 @@ jobs:
       - name: Build example
         shell: bash
         run: |
-          cd generator/${{ matrix.example }}
+          ls -1a
+          cd ../generator/${{ matrix.example }}
           pnpm nx run ${{ matrix.example }}:build
 
       - name: Save PNPM cache

--- a/.github/workflows/_generators.yml
+++ b/.github/workflows/_generators.yml
@@ -48,13 +48,13 @@ jobs:
         type: [application, sdk, preset]
         example:
           - 'country-info'
-          # - 'fake-api'
-          # - 'javascript-wiki'
-          # # - 'movies'
-          # - 'rfam'
-          # - 'stackexchange'
-          # - 'star-wars-api'
-          # - 'trippin'
+          - 'fake-api'
+          - 'javascript-wiki'
+          # - 'movies'
+          - 'rfam'
+          - 'stackexchange'
+          - 'star-wars-api'
+          - 'trippin'
         nx_version: [15.4]
     steps:
       - name: Check out repository
@@ -83,7 +83,7 @@ jobs:
         with:
           name: nx-mesh
 
-      - name: Test Generator - (nx-${{ matrix.nx_version }}/${{ matrix.type }}-${{ matrix.example }})
+      - name: Test Generator - (node-${{ inputs.node_version }}/nx-${{ matrix.nx_version }}/${{ matrix.type }}-${{ matrix.example }})
         shell: bash
         run: |
           cd ../

--- a/.github/workflows/_generators.yml
+++ b/.github/workflows/_generators.yml
@@ -86,16 +86,15 @@ jobs:
       - name: Generate repo
         shell: bash
         run: |
-          ls -1a
           cd ../
-          ls -1a
           pnpm dlx create-nx-workspace@${{ matrix.nx_version }} \
             --name=generator \
             --appName=${{ matrix.nx_version }} \
             --preset=ts \
             --interactive=false \
             --nxCloud=false \
-            --style=css
+            --style=css \
+            --skipGit
           cd generator
           ls -1a
           pnpm add ../project/dist/libs/nx-mesh/

--- a/.github/workflows/_generators.yml
+++ b/.github/workflows/_generators.yml
@@ -55,7 +55,14 @@ jobs:
           - 'stackexchange'
           - 'star-wars-api'
           - 'trippin'
-        nx_version: [15.4]
+        nx_version:
+          - 14.8
+          - 15
+          - 15.1
+          - 15.2
+          - 15.3
+          - 15.4
+          - latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/_generators.yml
+++ b/.github/workflows/_generators.yml
@@ -57,10 +57,10 @@ jobs:
           - 'trippin'
         nx_version: [latest, 15.4, 15.3, 15.2, 15.1, 15.0, 14]
     steps:
-      # - name: Check out repository
-      #   uses: actions/checkout@v3
-      #   with:
-      #     fetch-depth: 0
+      - name: Check out repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Setup Job
         uses: ./.github/actions/setup-job
@@ -87,6 +87,8 @@ jobs:
         shell: bash
         run: |
           ls -1a
+          cd ../
+          ls -1a
           pnpm dlx create-nx-workspace@${{ matrix.nx_version }} \
             --name=generator \
             --appName=${{ matrix.nx_version }} \
@@ -95,7 +97,8 @@ jobs:
             --nxCloud=false \
             --style=css
           cd generator
-          pnpm add ../dist/libs/nx-mesh/
+          ls -1a
+          pnpm add ../project/dist/libs/nx-mesh/
 
       - name: Generate Example
         shell: bash

--- a/.github/workflows/_generators.yml
+++ b/.github/workflows/_generators.yml
@@ -88,8 +88,7 @@ jobs:
         shell: bash
         run: |
           ls -1a
-          ls -1a dist
-          ls -1a dist/libs/nx-mesh
+          ls -1a nx-mesh
           cd ../
           ls -1a
           pnpm dlx create-nx-workspace@${{ matrix.nx_version }} \
@@ -102,7 +101,7 @@ jobs:
             --skipGit
           cd generator
           ls -1a
-          pnpm add ../nx-mesh/dist/libs/nx-mesh/
+          pnpm add ../nx-mesh/nx-mesh/
           ls -1a
           pnpm exec nx generate nx-mesh:${{ matrix.type }} ${{ matrix.example }} \
             --example=${{ matrix.example }} \

--- a/.github/workflows/_generators.yml
+++ b/.github/workflows/_generators.yml
@@ -40,7 +40,7 @@ env:
 
 jobs:
   generator:
-    name: Generator - ${{ matrix.type }}/${{ matrix.example }}
+    name: Generator - nx-${{ matrix.nx_version }}/${{ matrix.type }}/${{ matrix.example }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:

--- a/.github/workflows/_generators.yml
+++ b/.github/workflows/_generators.yml
@@ -55,7 +55,7 @@ jobs:
           - 'stackexchange'
           - 'star-wars-api'
           - 'trippin'
-        nx_version: [latest, 15.4, 15.3, 15.2, 15.1, 15.0, 14]
+        nx_version: [15.4]
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -102,8 +102,7 @@ jobs:
       - name: Generate Example
         shell: bash
         run: |
-          pnpm exec nx generate nx-mesh:${{ matrix.type }} \
-            ${{ matrix.example }} \
+          pnpm exec nx generate nx-mesh:${{ matrix.type }} ${{ matrix.example }} \
             --example=${{ matrix.example }} \
             --no-interactive
 

--- a/.github/workflows/_generators.yml
+++ b/.github/workflows/_generators.yml
@@ -98,7 +98,7 @@ jobs:
             --skipGit
           cd generator
           ls -1a
-          pnpm add ../project/dist/libs/nx-mesh/
+          pnpm add ../nx-mesh/dist/libs/nx-mesh/
           ls -1a
           pnpm exec nx generate nx-mesh:${{ matrix.type }} ${{ matrix.example }} \
             --example=${{ matrix.example }} \

--- a/.github/workflows/_generators.yml
+++ b/.github/workflows/_generators.yml
@@ -90,7 +90,7 @@ jobs:
           cd ../
           pnpm dlx create-nx-workspace@${{ matrix.nx_version }} \
             --name=generator \
-            --appName=${{ matrix.nx_version }} \
+            --appName=${{ matrix.example }} \
             --preset=next \
             --interactive=false \
             --nxCloud=false \

--- a/.github/workflows/_generators.yml
+++ b/.github/workflows/_generators.yml
@@ -44,6 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
+      fail-fast: false
       matrix:
         type: [application, sdk, preset]
         example:

--- a/.github/workflows/_generators.yml
+++ b/.github/workflows/_generators.yml
@@ -91,7 +91,7 @@ jobs:
           pnpm dlx create-nx-workspace@${{ matrix.nx_version }} \
             --name=generator \
             --appName=${{ matrix.example }} \
-            --preset=next \
+            --preset=ts \
             --interactive=false \
             --nxCloud=false \
             --style=css \

--- a/README.md
+++ b/README.md
@@ -83,11 +83,11 @@ yarn add -D nx-mesh
 
 ### Peer Dependencies
 
-| Name                  | Version       | Required | Auto-installed by generators |
-| --------------------- | ------------- | :------: | :--------------------------: |
-| `nx`                  | `>= 14 <= 16` |    ✅    |              -               |
-| `@graphql-mesh/cli`   | `>=0.71.0`    |    ✅    |              ✅              |
-| `@graphql-codgen/cli` | `>=2.16.1`    |    ✅    |              ✅              |
+| Name                  | Version    | Required | Auto-installed by generators |
+| --------------------- | ---------- | :------: | :--------------------------: |
+| `nx`                  | `>=15.4.1` |    ✅    |              -               |
+| `@graphql-mesh/cli`   | `>=0.71.0` |    ✅    |              ✅              |
+| `@graphql-codgen/cli` | `>=2.16.1` |    ✅    |              ✅              |
 
 <br/>
 

--- a/libs/nx-mesh/package.json
+++ b/libs/nx-mesh/package.json
@@ -26,15 +26,15 @@
     }
   },
   "dependencies": {
-    "@nrwl/cypress": "15.4.1",
-    "@nrwl/devkit": "15.4.1",
-    "@nrwl/js": "15.4.1",
-    "@nrwl/linter": "15.4.1",
-    "@nrwl/node": "15.4.1",
-    "@nrwl/workspace": "15.4.1",
+    "@nrwl/cypress": "^15.4.1",
+    "@nrwl/devkit": "^15.4.1",
+    "@nrwl/js": "^15.4.1",
+    "@nrwl/linter": "^15.4.1",
+    "@nrwl/node": "^15.4.1",
+    "@nrwl/workspace": "^15.4.1",
     "fs-extra": "^10.1.0",
     "get-port": "5.1.1",
-    "tslib": "2.4.0",
+    "tslib": "^2.4.0",
     "type-fest": "^2.18.0"
   },
   "keywords": [

--- a/libs/nx-mesh/src/generators/base/__snapshots__/base.spec.ts.snap
+++ b/libs/nx-mesh/src/generators/base/__snapshots__/base.spec.ts.snap
@@ -1773,7 +1773,8 @@ exports[`generators/base app directory --linter should use eslint for linting 1`
   ],
   \\"ignorePatterns\\": [
     \\"!**/*\\",
-    \\".mesh\\"
+    \\".mesh\\",
+    \\".codegen\\"
   ],
   \\"overrides\\": [
     {
@@ -1811,7 +1812,8 @@ exports[`generators/base app directory --linter should use eslint for linting 2`
   ],
   \\"ignorePatterns\\": [
     \\"!**/*\\",
-    \\".mesh\\"
+    \\".mesh\\",
+    \\".codegen\\"
   ],
   \\"overrides\\": [
     {
@@ -1849,7 +1851,8 @@ exports[`generators/base app directory --linter should use eslint for linting 3`
   ],
   \\"ignorePatterns\\": [
     \\"!**/*\\",
-    \\".mesh\\"
+    \\".mesh\\",
+    \\".codegen\\"
   ],
   \\"overrides\\": [
     {
@@ -1887,7 +1890,8 @@ exports[`generators/base app directory --linter should use eslint for linting 4`
   ],
   \\"ignorePatterns\\": [
     \\"!**/*\\",
-    \\".mesh\\"
+    \\".mesh\\",
+    \\".codegen\\"
   ],
   \\"overrides\\": [
     {
@@ -1925,7 +1929,8 @@ exports[`generators/base app directory --linter should use eslint for linting 5`
   ],
   \\"ignorePatterns\\": [
     \\"!**/*\\",
-    \\".mesh\\"
+    \\".mesh\\",
+    \\".codegen\\"
   ],
   \\"overrides\\": [
     {
@@ -2904,7 +2909,8 @@ exports[`generators/base app with standalone config --linter should use eslint f
   ],
   \\"ignorePatterns\\": [
     \\"!**/*\\",
-    \\".mesh\\"
+    \\".mesh\\",
+    \\".codegen\\"
   ],
   \\"overrides\\": [
     {
@@ -4910,7 +4916,8 @@ exports[`generators/base lib directory --linter should use eslint for linting 1`
   ],
   \\"ignorePatterns\\": [
     \\"!**/*\\",
-    \\".mesh\\"
+    \\".mesh\\",
+    \\".codegen\\"
   ],
   \\"overrides\\": [
     {
@@ -4948,7 +4955,8 @@ exports[`generators/base lib directory --linter should use eslint for linting 2`
   ],
   \\"ignorePatterns\\": [
     \\"!**/*\\",
-    \\".mesh\\"
+    \\".mesh\\",
+    \\".codegen\\"
   ],
   \\"overrides\\": [
     {
@@ -4986,7 +4994,8 @@ exports[`generators/base lib directory --linter should use eslint for linting 3`
   ],
   \\"ignorePatterns\\": [
     \\"!**/*\\",
-    \\".mesh\\"
+    \\".mesh\\",
+    \\".codegen\\"
   ],
   \\"overrides\\": [
     {
@@ -5024,7 +5033,8 @@ exports[`generators/base lib directory --linter should use eslint for linting 4`
   ],
   \\"ignorePatterns\\": [
     \\"!**/*\\",
-    \\".mesh\\"
+    \\".mesh\\",
+    \\".codegen\\"
   ],
   \\"overrides\\": [
     {
@@ -5062,7 +5072,8 @@ exports[`generators/base lib directory --linter should use eslint for linting 5`
   ],
   \\"ignorePatterns\\": [
     \\"!**/*\\",
-    \\".mesh\\"
+    \\".mesh\\",
+    \\".codegen\\"
   ],
   \\"overrides\\": [
     {
@@ -6126,7 +6137,8 @@ exports[`generators/base lib with standalone config --linter should use eslint f
   ],
   \\"ignorePatterns\\": [
     \\"!**/*\\",
-    \\".mesh\\"
+    \\".mesh\\",
+    \\".codegen\\"
   ],
   \\"overrides\\": [
     {
@@ -6651,7 +6663,8 @@ exports[`generators/base nested within app directory --linter should use eslint 
   ],
   \\"ignorePatterns\\": [
     \\"!**/*\\",
-    \\".mesh\\"
+    \\".mesh\\",
+    \\".codegen\\"
   ],
   \\"overrides\\": [
     {
@@ -7173,7 +7186,8 @@ exports[`generators/base nested within lib directory --linter should use eslint 
   ],
   \\"ignorePatterns\\": [
     \\"!**/*\\",
-    \\".mesh\\"
+    \\".mesh\\",
+    \\".codegen\\"
   ],
   \\"overrides\\": [
     {

--- a/libs/nx-mesh/src/generators/base/lib/add-cypress.ts
+++ b/libs/nx-mesh/src/generators/base/lib/add-cypress.ts
@@ -1,13 +1,10 @@
 import type { Tree } from '@nrwl/devkit';
 import type { NormalizedOptions } from './normalize-options';
 
-import { ensurePackage } from '@nrwl/devkit';
 import { cypressProjectGenerator } from '@nrwl/cypress';
 import { Linter } from '@nrwl/linter';
 
 export async function addCypress(host: Tree, options: NormalizedOptions) {
-  await ensurePackage(host, '@nrwl/cypress', '^15.4.1');
-
   const task = await cypressProjectGenerator(host, {
     ...options,
     directory: options.projectParentDirectory,

--- a/libs/nx-mesh/src/generators/base/lib/add-cypress.ts
+++ b/libs/nx-mesh/src/generators/base/lib/add-cypress.ts
@@ -1,10 +1,13 @@
 import type { Tree } from '@nrwl/devkit';
 import type { NormalizedOptions } from './normalize-options';
 
+import { ensurePackage } from '@nrwl/devkit';
 import { cypressProjectGenerator } from '@nrwl/cypress';
 import { Linter } from '@nrwl/linter';
 
 export async function addCypress(host: Tree, options: NormalizedOptions) {
+  await ensurePackage(host, '@nrwl/cypress', '^15.4.1');
+
   const task = await cypressProjectGenerator(host, {
     ...options,
     directory: options.projectParentDirectory,

--- a/libs/nx-mesh/src/generators/base/lib/add-linting.ts
+++ b/libs/nx-mesh/src/generators/base/lib/add-linting.ts
@@ -34,7 +34,11 @@ export async function addLinting(
           ...value,
         };
 
-        config['ignorePatterns'] = [...config['ignorePatterns'], '.mesh'];
+        config['ignorePatterns'] = [
+          ...config['ignorePatterns'],
+          '.mesh',
+          '.codegen',
+        ];
 
         return config;
       }

--- a/libs/nx-mesh/src/generators/utils/create-mesh-example/add-dependencies.ts
+++ b/libs/nx-mesh/src/generators/utils/create-mesh-example/add-dependencies.ts
@@ -16,6 +16,7 @@ export function addDependencies(
     ...versions['@graphql-mesh/runtime'],
     ...versions['@graphql-mesh/utils'],
     ...versions['graphql'],
+    ...versions['@graphql-typed-document-node/core'],
   };
 
   examples[options.example].dependencies.forEach((dep) => {

--- a/libs/nx-mesh/src/utils/versions.ts
+++ b/libs/nx-mesh/src/utils/versions.ts
@@ -3,12 +3,18 @@ import { MeshPackages } from './mesh-packages';
 export type MeshPackageVersions = {
   [P in MeshPackages]?: Record<P, string>;
 } & {
+  '@graphql-typed-document-node/core': {
+    '@graphql-typed-document-node/core': string;
+  };
   graphql: {
     graphql: string;
   };
 };
 
 export const versions: MeshPackageVersions = {
+  '@graphql-typed-document-node/core': {
+    '@graphql-typed-document-node/core': '^3.1.1',
+  },
   '@graphql-codegen/cli': {
     '@graphql-codegen/cli': '2.16.1',
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,15 +188,15 @@ importers:
 
   libs/nx-mesh:
     specifiers:
-      '@nrwl/cypress': 15.4.1
-      '@nrwl/devkit': 15.4.1
-      '@nrwl/js': 15.4.1
-      '@nrwl/linter': 15.4.1
-      '@nrwl/node': 15.4.1
-      '@nrwl/workspace': 15.4.1
+      '@nrwl/cypress': ^15.4.1
+      '@nrwl/devkit': ^15.4.1
+      '@nrwl/js': ^15.4.1
+      '@nrwl/linter': ^15.4.1
+      '@nrwl/node': ^15.4.1
+      '@nrwl/workspace': ^15.4.1
       fs-extra: ^10.1.0
       get-port: 5.1.1
-      tslib: 2.4.0
+      tslib: ^2.4.0
       type-fest: ^2.18.0
     dependencies:
       '@nrwl/cypress': 15.4.1
@@ -207,7 +207,7 @@ importers:
       '@nrwl/workspace': 15.4.1
       fs-extra: 10.1.0
       get-port: 5.1.1
-      tslib: 2.4.0
+      tslib: 2.4.1
       type-fest: 2.18.0
 
 packages:
@@ -2892,7 +2892,7 @@ packages:
       debug: 4.3.4
       espree: 9.3.2
       globals: 13.16.0
-      ignore: 5.2.0
+      ignore: 5.2.4
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       minimatch: 3.1.2
@@ -5174,7 +5174,7 @@ packages:
       '@jest/types': 28.1.3
       '@jridgewell/trace-mapping': 0.3.17
       '@types/node': 18.11.17
-      chalk: 4.1.0
+      chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
       glob: 7.2.3
@@ -5839,7 +5839,7 @@ packages:
       ejs: 3.1.8
       ignore: 5.2.4
       semver: 7.3.4
-      tslib: 2.4.0
+      tslib: 2.4.1
     transitivePeerDependencies:
       - typescript
     dev: false
@@ -5857,7 +5857,7 @@ packages:
       ignore: 5.2.4
       nx: 15.4.1
       semver: 7.3.4
-      tslib: 2.4.0
+      tslib: 2.4.1
     transitivePeerDependencies:
       - typescript
     dev: false
@@ -5875,7 +5875,7 @@ packages:
       ignore: 5.2.4
       nx: 15.4.1_zhrgkbtg447ekvrhgcqluapfue
       semver: 7.3.4
-      tslib: 2.4.0
+      tslib: 2.4.1
     transitivePeerDependencies:
       - typescript
 
@@ -6025,7 +6025,7 @@ packages:
       '@nrwl/devkit': 15.4.1
       '@phenomnomnominal/tsquery': 4.1.1
       tmp: 0.2.1
-      tslib: 2.4.0
+      tslib: 2.4.1
     transitivePeerDependencies:
       - nx
       - typescript
@@ -6046,7 +6046,7 @@ packages:
       '@phenomnomnominal/tsquery': 4.1.1_typescript@4.8.4
       eslint: 8.15.0
       tmp: 0.2.1
-      tslib: 2.4.0
+      tslib: 2.4.1
     transitivePeerDependencies:
       - nx
       - typescript
@@ -6065,7 +6065,7 @@ packages:
       '@nrwl/devkit': 15.4.1_nx@15.4.1
       '@phenomnomnominal/tsquery': 4.1.1
       tmp: 0.2.1
-      tslib: 2.4.0
+      tslib: 2.4.1
     transitivePeerDependencies:
       - nx
       - typescript
@@ -6142,7 +6142,7 @@ packages:
       '@nrwl/webpack': 15.4.1
       '@nrwl/workspace': 15.4.1
       chalk: 4.1.0
-      tslib: 2.4.0
+      tslib: 2.4.1
     transitivePeerDependencies:
       - '@babel/core'
       - '@parcel/css'
@@ -6185,7 +6185,7 @@ packages:
       '@nrwl/webpack': 15.4.1_sozmacwj6gekpd6qfm54wgywha
       '@nrwl/workspace': 15.4.1_45yisgrp5ltyayotjg3pj2hina
       chalk: 4.1.0
-      tslib: 2.4.0
+      tslib: 2.4.1
     transitivePeerDependencies:
       - '@babel/core'
       - '@parcel/css'
@@ -6486,7 +6486,7 @@ packages:
       ts-node: 10.9.1
       tsconfig-paths: 3.14.1
       tsconfig-paths-webpack-plugin: 3.5.2
-      tslib: 2.4.0
+      tslib: 2.4.1
       webpack: 5.75.0
       webpack-dev-server: 4.11.1_webpack@5.75.0
       webpack-merge: 5.8.0
@@ -6566,7 +6566,7 @@ packages:
       ts-node: 10.9.1_b2ulvot2eensv5kijvirfsfnxq
       tsconfig-paths: 3.14.1
       tsconfig-paths-webpack-plugin: 3.5.2
-      tslib: 2.4.0
+      tslib: 2.4.1
       webpack: 5.75.0_@swc+core@1.2.173
       webpack-dev-server: 4.11.1_webpack@5.75.0
       webpack-merge: 5.8.0
@@ -6646,7 +6646,7 @@ packages:
       ts-node: 10.9.1_b2ulvot2eensv5kijvirfsfnxq
       tsconfig-paths: 3.14.1
       tsconfig-paths-webpack-plugin: 3.5.2
-      tslib: 2.4.0
+      tslib: 2.4.1
       webpack: 5.75.0_@swc+core@1.2.173
       webpack-dev-server: 4.11.1_webpack@5.75.0
       webpack-merge: 5.8.0
@@ -6712,7 +6712,7 @@ packages:
       rxjs: 6.6.7
       semver: 7.3.4
       tmp: 0.2.1
-      tslib: 2.4.0
+      tslib: 2.4.1
       yargs: 17.6.2
       yargs-parser: 21.1.1
     transitivePeerDependencies:
@@ -6757,7 +6757,7 @@ packages:
       rxjs: 6.6.7
       semver: 7.3.4
       tmp: 0.2.1
-      tslib: 2.4.0
+      tslib: 2.4.1
       yargs: 17.6.2
       yargs-parser: 21.1.1
     transitivePeerDependencies:
@@ -8747,7 +8747,7 @@ packages:
     engines: { node: '>=14.15.0' }
     dependencies:
       js-yaml: 3.14.1
-      tslib: 2.4.0
+      tslib: 2.4.1
 
   /@zkochan/js-yaml/0.0.6:
     resolution:
@@ -13324,7 +13324,7 @@ packages:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.0.5
+      minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
 
@@ -14949,7 +14949,7 @@ packages:
       '@jest/test-sequencer': 28.1.3
       '@jest/types': 28.1.3
       babel-jest: 28.1.3_@babel+core@7.20.7
-      chalk: 4.1.0
+      chalk: 4.1.2
       ci-info: 3.7.0
       deepmerge: 4.2.2
       glob: 7.2.3
@@ -14991,7 +14991,7 @@ packages:
       '@jest/types': 28.1.3
       '@types/node': 18.11.9
       babel-jest: 28.1.3_@babel+core@7.20.7
-      chalk: 4.1.0
+      chalk: 4.1.2
       ci-info: 3.7.0
       deepmerge: 4.2.2
       glob: 7.2.3
@@ -15335,7 +15335,7 @@ packages:
       }
     engines: { node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0 }
     dependencies:
-      chalk: 4.1.0
+      chalk: 4.1.2
       graceful-fs: 4.2.10
       jest-haste-map: 28.1.3
       jest-pnp-resolver: 1.2.3_jest-resolve@28.1.1
@@ -15467,7 +15467,7 @@ packages:
     dependencies:
       '@jest/types': 28.1.3
       '@types/node': 18.11.17
-      chalk: 4.1.0
+      chalk: 4.1.2
       ci-info: 3.7.0
       graceful-fs: 4.2.10
       picomatch: 2.3.1
@@ -19291,7 +19291,7 @@ packages:
     peerDependencies:
       postcss: 8.x
     dependencies:
-      chalk: 4.1.0
+      chalk: 4.1.2
       concat-with-sourcemaps: 1.1.0
       cssnano: 5.1.14_postcss@8.4.20
       import-cwd: 3.0.0
@@ -21018,6 +21018,7 @@ packages:
       {
         integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==,
       }
+    dev: false
 
   /tslib/2.4.1:
     resolution:

--- a/tools/scripts/nx-update.sh
+++ b/tools/scripts/nx-update.sh
@@ -105,12 +105,12 @@ function installUpdates {
         @nrwl/js@${version} && \
         cd libs/nx-mesh && \
         pnpm update \
-          @nrwl/cypress@${version} \
-          @nrwl/devkit@${version} \
-          @nrwl/js@${version} \
-          @nrwl/linter@${version} \
-          @nrwl/node@${version} \
-          @nrwl/workspace@${version} && \
+          @nrwl/cypress@^${version} \
+          @nrwl/devkit@^${version} \
+          @nrwl/js@^${version} \
+          @nrwl/linter@^${version} \
+          @nrwl/node@^${version} \
+          @nrwl/workspace@^${version} && \
         cd ../../ && \
         pnpm install
 


### PR DESCRIPTION
## What's Changed?

- Add missing peer dependency - `@graphql-typed-document-node/core`.
- Add `.codegen` to eslint ignore
- Nx dependencies use `^` ranges
- CI generator tests run on new repos
    - Test generators in clean repos
- Fix defined `nx` peer dependency versions
    - `nx-mesh` needs `nx@>=15.4.1` 