### PR TITLE
Fix `next` snapshot workflow

### DIFF
--- a/.changeset/brave-chairs-breathe.md
+++ b/.changeset/brave-chairs-breathe.md
@@ -1,0 +1,5 @@
+---
+'nx-mesh': patch
+---
+
+test

--- a/.changeset/brave-chairs-breathe.md
+++ b/.changeset/brave-chairs-breathe.md
@@ -1,5 +1,0 @@
----
-'nx-mesh': patch
----
-
-test

--- a/.github/workflows/_changesets.yml
+++ b/.github/workflows/_changesets.yml
@@ -102,7 +102,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Snapshot (${{ inputs.snapshot_tag }})
-        if: ${{ inputs.snapshot == 'true' && inputs.snapshot_tag != 'latest' && steps.changesets.outputs.published != 'true' }}
+        if: ${{ inputs.snapshot == true && inputs.snapshot_tag != 'latest' && steps.changesets.outputs.published != 'true' }}
         uses: the-guild-org/changesets-snapshot-action@eeff4d8aecffd035c3d5513d9811f07893737425 # v0.0.1
         with:
           tag: ${{ inputs.snapshot_tag }}

--- a/.github/workflows/_changesets.yml
+++ b/.github/workflows/_changesets.yml
@@ -17,6 +17,12 @@ on:
         required: false
         default: false
         type: boolean
+      snapshot:
+        description: >
+          Should a snapshot be published?
+        required: false
+        default: false
+        type: boolean
       snapshot_tag:
         description: >
           What should the snapshot tag be?
@@ -96,7 +102,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Snapshot (${{ inputs.snapshot_tag }})
-        if: ${{ inputs.snapshot_tag != 'latest' && steps.changesets.outputs.published != 'true' }}
+        if: ${{ inputs.snapshot == 'true' && inputs.snapshot_tag != 'latest' && steps.changesets.outputs.published != 'true' }}
         uses: the-guild-org/changesets-snapshot-action@eeff4d8aecffd035c3d5513d9811f07893737425 # v0.0.1
         with:
           tag: ${{ inputs.snapshot_tag }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,7 +85,6 @@ jobs:
     secrets: inherit
     with:
       release: true
-      snapshot_tag: next
 
   deploy:
     needs: [lint, build, test, e2e, generators, changesets]

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -1,7 +1,7 @@
 name: 'Next Release'
 
 on:
-  push:
+  pull_request:
     branches:
       - changeset-release/main
 

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -1,7 +1,7 @@
 name: 'Next Release'
 
 on:
-  pull_request:
+  push:
     branches:
       - changeset-release/main
 

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: release--${{ github.workflow }}--${{ github.ref }}
+  group: release--main--${{ github.workflow }}--${{ github.ref }}
 
 env:
   NX__TRIPPIN__API_KEY: ${{ secrets.NX__TRIPPIN__API_KEY }}

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -1,4 +1,4 @@
-name: 'Main'
+name: 'Next Release'
 
 on:
   push:

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -1,0 +1,24 @@
+name: 'Main'
+
+on:
+  push:
+    branches:
+      - changeset-release/main
+
+  workflow_dispatch:
+
+concurrency:
+  group: release--${{ github.workflow }}--${{ github.ref }}
+
+env:
+  NX__TRIPPIN__API_KEY: ${{ secrets.NX__TRIPPIN__API_KEY }}
+  NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+
+jobs:
+  changesets:
+    name: Changesets
+    uses: ./.github/workflows/_changesets.yml
+    secrets: inherit
+    with:
+      snapshot: true
+      snapshot_tag: next

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -92,4 +92,5 @@ jobs:
     secrets: inherit
     with:
       affected: true
+      snapshot: true
       snapshot_tag: alpha


### PR DESCRIPTION
The `next` snapshot release hasn't been triggering.

## What's Changed

1. Create a new `next` workflow that publishes the `next` snapshot